### PR TITLE
Update RUV for out-of-sample, centering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install .
+            pip install --upgrade --no-deps --force-reinstall .
 
       - save_cache:
           paths:

--- a/genemunge/normalize.py
+++ b/genemunge/normalize.py
@@ -200,7 +200,7 @@ class RemoveUnwantedVariation(object):
         applied out-of-sample.
 
         Args:
-            center (bool): whether to center the gene means in the fit.
+            center (optional; bool): whether to center the gene means in the fit.
             hk_genes (optional; List[str]): list of housekeeping genes
             means (optional; numpy array ~ (num_genes,))
             U (optional; numpy array ~ (num_training_samples, num_factors))

--- a/genemunge/normalize.py
+++ b/genemunge/normalize.py
@@ -352,7 +352,7 @@ class RemoveUnwantedVariation(object):
         else:
             data_trans = data
         W = numpy.dot(data_trans[self.hk_genes], self.Vt.T)
-        return data - self._delta(W, data_centered, penalty)
+        return data - self._delta(W, data_trans, penalty)
 
     def fit_transform(self, data, hk_genes, penalty=0, variance_cutoff=0.9):
         """

--- a/tests/genemunge/test_normalize.py
+++ b/tests/genemunge/test_normalize.py
@@ -119,7 +119,7 @@ def test_remove_unwanted_variation_noX():
     alpha = np.random.randn(num_hidden_factors, num_genes)
 
     Y = pd.DataFrame(np.dot(W, alpha))
-    ruv = normalize.RemoveUnwantedVariation()
+    ruv = normalize.RemoveUnwantedVariation(center=True)
     Y_tilde = ruv.fit_transform(Y, np.arange(num_genes), variance_cutoff=1)
 
     assert np.allclose(Y.mean(axis=0), Y_tilde.mean(axis=0))
@@ -145,7 +145,7 @@ def test_remove_unwanted_variation():
     Yr = np.dot(X, beta)[:, num_hk_genes:] + np.dot(W, alpha)[:, num_hk_genes:]
 
     Y = pd.DataFrame(np.hstack([Yc, Yr]))
-    ruv = normalize.RemoveUnwantedVariation()
+    ruv = normalize.RemoveUnwantedVariation(center=False)
     Y_tilde = ruv.fit_transform(Y, np.arange(num_hk_genes), variance_cutoff=1)
 
     # check the W factor count estimate


### PR DESCRIPTION
Two changes to RUV:
- Gene centering is performed.  During `fit`, the means of each gene `<Y>` of the training data `Y` are stored and `Y - <Y>` is used in the fit.  In `transform`, `Yt - <Y>` is used in computing the correction term `Delta`; the transformed data is `Yt - Delta`.
- The out-of-sample correction is updated to just use the control (housekeeping) genes to fit `W`.  This ensures the out-of-sample correction on a dataset `Yt` matches the in-sample correction on the training dataset `Y` when `Yt = Y`.
