### PR TITLE
Hotfix for Tissue Stats

### DIFF
--- a/genemunge/describe.py
+++ b/genemunge/describe.py
@@ -30,7 +30,8 @@ class Describer(object):
 
     """
 
-    __stats__ = ['mean', 'median', 'std', 'lower_quartile', 'upper_quartile', 'fraction_zero']
+    __stats__ = ['mean', 'median', 'std', 'lower_quartile', 'upper_quartile',
+                 'fraction_zero', 'hellinger']
 
     def __init__(self, identifier='symbol', load_tissue_data=True):
         """


### PR DESCRIPTION
Adds the `hellinger` key to the `Describer.__stats__` attribute so that it is accessible through the `tissue_stats` DataFrame.