### PR TITLE
Add a parameter to set the max number of components used in RUV

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,14 @@
 genemunge
 =========
 
-Tools for munging genomic data such as: - Converting between different
-types of gene identifiers - Searching for terms in the Gene Ontology
-(GO) associated with a keyword - Looking up housekeeping genes and
-transcription factors - Getting a list of GO terms associated with a
-given gene - Looking up how a gene is expressed across tissues -
-Normalizing a matrix of gene expression data by converting to TPM
+Tools for munging genomic data such as:
+
+- Converting between different types of gene identifiers
+- Searching for terms in the Gene Ontology (GO) associated with a keyword
+- Looking up housekeeping genes and transcription factors
+- Getting a list of GO terms associated with a given gene
+- Looking up how a gene is expressed across tissues
+- Normalizing a matrix of gene expression data by converting to TPM
 
 Unlearn.AI
 ----------
@@ -19,13 +21,14 @@ to extract insights from their omics data. Learn more at
 Install
 -------
 
-This library is accompanied by the following data sources: - The `Gene
-Ontology <http://geneontology.org/>`__. The current version used here is
-the 2018-03-27 release. -
-`recount2 <https://jhubiostatistics.shinyapps.io/recount/>`__ data for
-GTEx. - `HGNC <https://www.genenames.org/>`__ gene symbols. - A list of
-`transcription factors <http://www.tfcheckpoint.org/>`__. - A list of
-`housekeeping genes <https://www.tau.ac.il/~elieis/HKG/>`__.
+This library is accompanied by the following data sources:
+
+- The `Gene Ontology <http://geneontology.org/>`__. The current version used
+here is the 2018-03-27 release.
+- `recount2 <https://jhubiostatistics.shinyapps.io/recount/>`__ data for GTEx.
+- `HGNC <https://www.genenames.org/>`__ gene symbols.
+- A list of `transcription factors <http://www.tfcheckpoint.org/>`__.
+- A list of `housekeeping genes <https://www.tau.ac.il/~elieis/HKG/>`__.
 
 Installing this package through ``pip`` (``pip install genemunge`` from PyPI,
 ``pip install .`` from GitHub) will use the static data that accompanies this repository.
@@ -46,7 +49,8 @@ Citations
 Please cite the following papers if you make use of genemunge for a
 publication.
 
-This package:
+This package: Fisher C, Smith A, Walsh J,
+https://www.biorxiv.org/content/early/2018/04/10/299107
 
 Gene Ontology: Ashburner et al. Gene ontology: tool for the unification
 of biology (2000) Nat Genet 25(1):25-9 GO Consortium, Nucleic Acids

--- a/genemunge/normalize.py
+++ b/genemunge/normalize.py
@@ -48,7 +48,8 @@ def impute(data, scale=0.5):
 
     """
     v = scale * data[data > 0].min(axis=1)
-    return data.fillna(0).T.replace(to_replace=0, value=v).T
+    data_fill = data.fillna(0)
+    return data_fill + (data_fill == 0).multiply(v, axis=0)
 
 
 class Normalizer(object):

--- a/genemunge/normalize.py
+++ b/genemunge/normalize.py
@@ -230,10 +230,10 @@ class RemoveUnwantedVariation(object):
             bool
 
         """
-        return (self.hk_genes is not None) or \
-               (self.means is not None) or \
-               (self.U is not None) or \
-               (self.L is not None) or \
+        return (self.hk_genes is not None) and \
+               (self.means is not None) and \
+               (self.U is not None) and \
+               (self.L is not None) and \
                (self.Vt is not None)
 
     def _cutoff_svd(self, matrix, variance_cutoff=1, num_components=None):

--- a/genemunge/normalize.py
+++ b/genemunge/normalize.py
@@ -213,7 +213,7 @@ class RemoveUnwantedVariation(object):
 
         """
         self.center = center
-        self.hk_genes =None
+        self.hk_genes = None
         self.means = None
         self.U = None
         self.L = None
@@ -236,7 +236,7 @@ class RemoveUnwantedVariation(object):
                (self.L is not None) or \
                (self.Vt is not None)
 
-    def _cutoff_svd(self, matrix, variance_cutoff=1):
+    def _cutoff_svd(self, matrix, variance_cutoff=1, num_components=None):
         """
         Compute the singular value decomposition of a matrix and get rid
         of any singular vectors below a cumulative variance threshold.
@@ -245,6 +245,8 @@ class RemoveUnwantedVariation(object):
             matrix (numpy array): the data
             variance_cutoff (float): retains only elements of L that contribute
                 to the cumulative fractional variance up to the cutoff.
+            num_components (int): the maximum number of components of L to use.
+                If None, no additional constraint is applied.
 
         Returns:
             U, L, Vt where M = U L V^{T}
@@ -254,10 +256,12 @@ class RemoveUnwantedVariation(object):
         # trim eigenvalues close to 0, exploit the fact that L is ordered
         L = L[:(~numpy.isclose(L, 0)).sum()]
         cumul_variance_fracs = numpy.cumsum(L**2) / numpy.sum(L**2)
-        L_cutoff = min(len(L), 1+numpy.searchsorted(cumul_variance_fracs, variance_cutoff))
+        max_components = len(L) if num_components is None else num_components
+        L_cutoff = min(max_components,
+                       1+numpy.searchsorted(cumul_variance_fracs, variance_cutoff))
         return U[:, :L_cutoff], L[:L_cutoff], Vt[:L_cutoff, :]
 
-    def fit(self, data, hk_genes, variance_cutoff=0.9):
+    def fit(self, data, hk_genes, variance_cutoff=0.9, num_components=None):
         """
         Perform a singular value decomposition of the housekeeping genes to
         fit the transform.
@@ -287,6 +291,8 @@ class RemoveUnwantedVariation(object):
             hk_genes (List[str]): list of housekeeping genes
             variance_cutoff (float): the cumulative variance cutoff on SVD
                 eigenvalues of Y_c (the variance fraction of the factors).
+            num_components (int): the maximum number of components K to use.
+                If None, all components are used (up to the variance cutoff).
 
         Returns:
             None
@@ -300,7 +306,8 @@ class RemoveUnwantedVariation(object):
             housekeeping = data[self.hk_genes] - self.means[self.hk_genes]
         else:
             housekeeping = data[self.hk_genes]
-        self.U, self.L, self.Vt = self._cutoff_svd(housekeeping, variance_cutoff)
+        self.U, self.L, self.Vt = self._cutoff_svd(housekeeping, variance_cutoff,
+                                                   num_components)
 
     def _delta(self, W, data_centered, penalty):
         """
@@ -355,7 +362,8 @@ class RemoveUnwantedVariation(object):
         W = numpy.dot(data_trans[self.hk_genes], self.Vt.T)
         return data - self._delta(W, data_trans, penalty)
 
-    def fit_transform(self, data, hk_genes, penalty=0, variance_cutoff=0.9):
+    def fit_transform(self, data, hk_genes, penalty=0, variance_cutoff=0.9,
+                      num_components=None):
         """
         Perform the 2-step Remove Unwanted Variation (RUV-2) algorithm.
 
@@ -366,12 +374,14 @@ class RemoveUnwantedVariation(object):
             penalty (float): regularization on the regression step
             variance_cutoff (float): the cumulative variance cutoff on SVD
                 eigenvalues of Y_c.
+            num_components (int): the maximum number of components K to use.
+                If None, all components are used (up to the variance cutoff).
 
         Returns:
             batch corrected data (pandas.DataFrame ~ (num_samples, num_genes))
 
         """
-        self.fit(data, hk_genes, variance_cutoff)
+        self.fit(data, hk_genes, variance_cutoff, num_components)
         return self.transform(data, penalty)
 
     def save(self, filename, overwrite_existing=False):

--- a/tests/genemunge/test_normalize.py
+++ b/tests/genemunge/test_normalize.py
@@ -152,5 +152,33 @@ def test_remove_unwanted_variation():
     assert ruv.L.shape[0] == num_W_factors
 
 
+def test_remove_unwanted_variation_component_cut():
+    """Test that the RUV2 implementation correctly trims the number of
+    irrelevant factors on a constructed example."""
+    num_samples = 200
+    num_genes = 1000
+    num_hk_genes = 100
+    num_X_factors = 20
+    num_W_factors = 10
+    num_components = 3
+
+    X = np.random.randn(num_samples, num_X_factors)
+    beta = np.random.randn(num_X_factors, num_genes)
+
+    W = np.random.randn(num_samples, num_W_factors)
+    alpha = np.random.randn(num_W_factors, num_genes)
+
+    Yc = np.dot(W, alpha)[:, :num_hk_genes]
+    Yr = np.dot(X, beta)[:, num_hk_genes:] + np.dot(W, alpha)[:, num_hk_genes:]
+
+    Y = pd.DataFrame(np.hstack([Yc, Yr]))
+    ruv = normalize.RemoveUnwantedVariation(center=False)
+    Y_tilde = ruv.fit_transform(Y, np.arange(num_hk_genes), variance_cutoff=1,
+                                num_components=num_components)
+
+    # check the W factor count estimate
+    assert ruv.L.shape[0] == num_components
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Adds a flag `num_components` to RUV’s `fit` and `fit_transform` that sets the maximum number of components (irrelevant factors) used.  Default is `None`, which places no constraint.

A couple of other changes:
- Sped up the `impute` function a lot for larger expression arrays.
- Fixed some formatting problems in the README.
