### PR TITLE
Add ALR Transform to Normalize

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,7 @@ Install
 
 This library is accompanied by the following data sources:
 
-- The `Gene Ontology <http://geneontology.org/>`__. The current version used
-here is the 2018-03-27 release.
+- The `Gene Ontology <http://geneontology.org/>`__. The current version used here is the 2018-03-27 release.
 - `recount2 <https://jhubiostatistics.shinyapps.io/recount/>`__ data for GTEx.
 - `HGNC <https://www.genenames.org/>`__ gene symbols.
 - A list of `transcription factors <http://www.tfcheckpoint.org/>`__.

--- a/genemunge/describe.py
+++ b/genemunge/describe.py
@@ -91,8 +91,9 @@ class Describer(object):
         gene_id = self.get_ensembl(identifier)
         if gene_id != gene_id:
             raise KeyError("Unknown identifier {}".format(identifier))
-        return pandas.concat(
-                {k: self.tissue_stats[k].loc[gene_id] for k in self.__stats__}, axis=1)
+        stats = [s for s in self.__stats__ if s != 'hellinger']
+        return pandas.concat({k: self.tissue_stats[k].loc[gene_id] for k in stats},
+                              axis=1)
 
     def plot_tissue_expression(self, identifier, sortby=None, show=True, filename=None):
         """


### PR DESCRIPTION
1. Fixes a bug in the `Describer.get_tissue_stats` method. This function should not return the Hellinger metric between tissues.

2. Adds a method `Normalizer.alr_from_tpm` to compute the additive log ratio transform from data in transcripts per million format. The centered log ratio transform, which we currently have, uses the geometric mean of the expression values as a reference to normalize the log gene expression. The new alr method does the same thing, but with a subset of genes called `reference_genes`. The reference genes are dropped from the data. If there is only one reference gene, then our alr method corresponds to the usual use of the term in the literature on compositional data analysis. 