### PR TITLE
Update tissue stats calculation

### DIFF
--- a/genemunge/data/gtex/process_gtex.py
+++ b/genemunge/data/gtex/process_gtex.py
@@ -108,7 +108,7 @@ def create_tissue_stats():
                 fraction_zero, pandas.DataFrame(
                         (tpm == 0).mean().astype(float), columns=[t])], axis=1)
         # Convert tpms to clr with 0.5*min imputation
-        clr = norm.clr_from_tpm(tissue_expression, imputer=normalize.impute)
+        clr = norm.clr_from_tpm(tpm, imputer=normalize.impute)
         mean_clr = pandas.concat(
                 [mean_clr, pandas.DataFrame(clr.mean(), columns=[t])], axis=1)
         median_clr = pandas.concat(

--- a/genemunge/describe.py
+++ b/genemunge/describe.py
@@ -77,32 +77,33 @@ class Describer(object):
         except AttributeError:
             pass
 
-    def get_tissue_expression(self, identifier):
+    def get_tissue_expression(self, gene_identifier):
         """
         Get statistics describing the expression of a gene across tissues
         in healthy people (from GTEx).
 
         Args:
-            identifier (str)
+            gene_identifier (str): the identifier for the gene.
 
         Returns:
             pandas.DataFrame
 
         """
-        gene_id = self.get_ensembl(identifier)
+        gene_id = self.get_ensembl(gene_identifier)
         if gene_id != gene_id:
-            raise KeyError("Unknown identifier {}".format(identifier))
+            raise KeyError("Unknown gene identifier {}".format(gene_identifier))
         stats = [s for s in self.__stats__ if s not in ['hellinger', 'hellinger_clr']]
         return pandas.concat({k: self.tissue_stats[k].loc[gene_id] for k in stats},
                               axis=1)
 
-    def plot_tissue_expression(self, identifier, sortby=None, show=True, filename=None):
+    def plot_tissue_expression(self, gene_identifier, sortby=None, show=True,
+                               filename=None):
         """
         Plot the expression of a gene across tissues in health people
         (from GTEx).
 
         Args:
-            identifier (str)
+            gene_identifier (str): the identifier for the gene.
             sortby (optional; str): 'median', 'mean', 'std', 'lower_quartile'
                 or 'upper_quartile'. if None, then tissues are alphabetical
             filename (optional; str)
@@ -111,7 +112,7 @@ class Describer(object):
             None
 
         """
-        tissue_stats = self.get_tissue_expression(identifier)
+        tissue_stats = self.get_tissue_expression(gene_identifier)
 
         if sortby is not None:
             stats = tissue_stats.sort_values(sortby)
@@ -148,7 +149,7 @@ class Describer(object):
 
         ax.set_ylim([min_y - 0.1 * min_y, max_y + 0.1 * max_y])
         plt.xticks(numpy.arange(len(tissues)) + 1, tissues, rotation='vertical')
-        ax.set_title(identifier)
+        ax.set_title(gene_identifier)
         ax.set_ylabel('TPM')
 
         if show:
@@ -176,7 +177,7 @@ class Describer(object):
                 terms += [term]
         return list(set(terms))
 
-    def get_gene_info(self, identifier):
+    def get_gene_info(self, gene_identifier):
         """
         Get some information about a gene such as:
             ensemble_gene_id
@@ -185,14 +186,14 @@ class Describer(object):
             associated categories in the Gene Ontology
 
         Args:
-            identifier (str)
+            gene_identifier (str): the identifier for the gene.
 
         Returns:
             None
 
         """
         gene_info = {}
-        gene_info['ensembl'] = self.get_ensembl(identifier)
+        gene_info['ensembl'] = self.get_ensembl(gene_identifier)
         gene_info['symbol'] = self.get_symbol(gene_info['ensembl'])
         gene_info['name'] = self.get_name(gene_info['ensembl'])
         gene_info['ontology'] = {i: self.searcher.go[i]['name']

--- a/genemunge/normalize.py
+++ b/genemunge/normalize.py
@@ -270,9 +270,18 @@ class Normalizer(object):
             pandas.DataFrame ~ (num_samples, num_genes - num_reference_genes)
 
         """
-        # set up an object to describe genes
-        mean_clr = self.describer.tissue_stats['mean_clr'].reindex(gene_list)
-        std_clr = self.describer.tissue_stats['std_clr'].reindex(gene_list)
+        # get the clr tissue stats from GTEx
+        mean_clr = pandas.DataFrame(index=gene_list,
+                        columns=self.describer.tissue_stats['mean_clr'].columns)
+        std_clr = pandas.DataFrame(index=gene_list,
+                        columns=self.describer.tissue_stats['std_clr'].columns)
+        if gene_list is None:
+            gene_list = data.columns
+        for gene in gene_list:
+            gene_tissue_expr = self.describer.get_tissue_expression(gene)
+            mean_clr.loc[gene] = gene_tissue_expr['mean_clr']
+            std_clr.loc[gene] = gene_tissue_expr['std_clr']
+
         mean_expression = mean_clr[tissues].transpose().set_index(tissues.index)
         std_expression = std_clr[tissues].transpose().set_index(tissues.index)
         data_subset = self.reindex(data, gene_list)

--- a/tests/genemunge/test_normalize.py
+++ b/tests/genemunge/test_normalize.py
@@ -193,6 +193,7 @@ def test_zscore_from_clr(expression_data):
 
     tissues = pd.Series('Liver', index=clr.index)
     zscore = norm.z_score_from_clr(clr, tissues)
+    assert zscore.shape == clr.shape
 
 
 def test_ordinalize(expression_data):

--- a/tests/genemunge/test_normalize.py
+++ b/tests/genemunge/test_normalize.py
@@ -183,6 +183,30 @@ def test_gtex_reindex(expression_data):
     assert (tpm.columns == norm.gene_lengths.index).all()
 
 
+def test_zscore_from_clr(expression_data):
+    """Test the z-score transformation on CLR data."""
+    identifier = 'symbol'
+    norm = normalize.Normalizer(identifier=identifier)
+
+    tpm = normalize.impute(expression_data.tpm)
+    clr = norm.clr_from_tpm(tpm, gene_list=tpm.columns)
+
+    tissues = pd.Series('Liver', index=clr.index)
+    zscore = norm.z_score_from_clr(clr, tissues)
+
+
+def test_ordinalize(expression_data):
+    """Test the ordinalize transformation on CLR data."""
+    identifier = 'symbol'
+    norm = normalize.Normalizer(identifier=identifier)
+
+    tpm = normalize.impute(expression_data.tpm)
+    clr = norm.clr_from_tpm(tpm, gene_list=tpm.columns)
+
+    cutoffs = [0]
+    ords = norm.ordinalize(clr, cutoffs)
+
+
 def test_remove_unwanted_variation_noX():
     """Test the RUV2 implementation for data with no X."""
     num_samples = 100

--- a/tests/genemunge/test_normalize.py
+++ b/tests/genemunge/test_normalize.py
@@ -203,8 +203,11 @@ def test_ordinalize(expression_data):
     tpm = normalize.impute(expression_data.tpm)
     clr = norm.clr_from_tpm(tpm, gene_list=tpm.columns)
 
-    cutoffs = [0]
-    ords = norm.ordinalize(clr, cutoffs)
+    cutoffs = [0.37]
+    min_value = 5
+    ords = norm.ordinalize(clr, cutoffs, min_value=min_value)
+    assert ((clr <= cutoffs[0]) == (ords == min_value)).all().all()
+    assert ((clr > cutoffs[0]) == (ords == 1+min_value)).all().all()
 
 
 def test_remove_unwanted_variation_noX():


### PR DESCRIPTION
On top of #80.

Changes the calculation of per-tissue statistics on GTEx for the CLR transform to calculate from TPMs instead of counts.  This updates the tissue stats file saved in the repo.
